### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ master_doc = 'index'
 # General substitutions.
 project = 'The Pyramid Web Framework'
 thisyear = datetime.datetime.now().year
-copyright = '2008-%s, Agendaless Consulting' % thisyear
+copyright = '2008-{0!s}, Agendaless Consulting'.format(thisyear)
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
@@ -154,7 +154,7 @@ html_theme_options = dict(
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'The Pyramid Web Framework v%s' % release
+html_title = 'The Pyramid Web Framework v{0!s}'.format(release)
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -412,11 +412,10 @@ def resig(app, what, name, obj, options, signature, return_annotation):
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = 'The Pyramid Web Framework, Version %s' \
-             % release
+epub_title = 'The Pyramid Web Framework, Version {0!s}'.format(release)
 epub_author = 'Chris McDonough'
 epub_publisher = 'Agendaless Consulting'
-epub_copyright = '2008-%d' % thisyear
+epub_copyright = '2008-{0:d}'.format(thisyear)
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.
@@ -430,8 +429,7 @@ epub_scheme = 'ISBN'
 epub_identifier = '0615445675'
 
 # A unique identification for the text.
-epub_uid = 'The Pyramid Web Framework, Version %s' \
-           % release
+epub_uid = 'The Pyramid Web Framework, Version {0!s}'.format(release)
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['_static/opensearch.xml', '_static/doctools.js',

--- a/docs/narr/hellotraversal.py
+++ b/docs/narr/hellotraversal.py
@@ -9,7 +9,7 @@ def get_root(request):
     return Resource({'a': Resource({'b': Resource({'c': Resource()})})})
 
 def hello_world_of_resources(context, request):
-    output = "Here's a resource and its children: %s" % context
+    output = "Here's a resource and its children: {0!s}".format(context)
     return Response(output)
 
 if __name__ == '__main__':

--- a/docs/narr/helloworld.py
+++ b/docs/narr/helloworld.py
@@ -4,7 +4,7 @@ from pyramid.response import Response
 
 
 def hello_world(request):
-    return Response('Hello %(name)s!' % request.matchdict)
+    return Response('Hello {name!s}!'.format(**request.matchdict))
 
 if __name__ == '__main__':
     config = Configurator()

--- a/docs/quick_tour/requests/app.py
+++ b/docs/quick_tour/requests/app.py
@@ -8,7 +8,7 @@ def hello_world(request):
     url = request.url
     name = request.params.get('name', 'No Name Provided')
 
-    body = 'URL %s with name: %s' % (url, name)
+    body = 'URL {0!s} with name: {1!s}'.format(url, name)
     return Response(
         content_type="text/plain",
         body=body

--- a/docs/quick_tour/routing/views.py
+++ b/docs/quick_tour/routing/views.py
@@ -4,5 +4,5 @@ from pyramid.view import view_config
 
 @view_config(route_name='hello')
 def hello_world(request):
-    body = '<h1>Hi %(first)s %(last)s!</h1>' % request.matchdict
+    body = '<h1>Hi {first!s} {last!s}!</h1>'.format(**request.matchdict)
     return Response(body)

--- a/docs/quick_tutorial/request_response/tutorial/views.py
+++ b/docs/quick_tutorial/request_response/tutorial/views.py
@@ -15,7 +15,7 @@ class TutorialViews:
     def plain(self):
         name = self.request.params.get('name', 'No Name Provided')
 
-        body = 'URL %s with name: %s' % (self.request.url, name)
+        body = 'URL {0!s} with name: {1!s}'.format(self.request.url, name)
         return Response(
             content_type='text/plain',
             body=body

--- a/docs/tutorials/wiki/src/authorization/tutorial/views.py
+++ b/docs/tutorials/wiki/src/authorization/tutorial/views.py
@@ -35,10 +35,10 @@ def view_page(context, request):
         if word in wiki:
             page = wiki[word]
             view_url = request.resource_url(page)
-            return '<a href="%s">%s</a>' % (view_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, word)
         else:
             add_url = request.application_url + '/add_page/' + word 
-            return '<a href="%s">%s</a>' % (add_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, word)
 
     content = publish_parts(context.data, writer_name='html')['html_body']
     content = wikiwords.sub(check, content)

--- a/docs/tutorials/wiki/src/tests/tutorial/views.py
+++ b/docs/tutorials/wiki/src/tests/tutorial/views.py
@@ -35,10 +35,10 @@ def view_page(context, request):
         if word in wiki:
             page = wiki[word]
             view_url = request.resource_url(page)
-            return '<a href="%s">%s</a>' % (view_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, word)
         else:
             add_url = request.application_url + '/add_page/' + word 
-            return '<a href="%s">%s</a>' % (add_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, word)
 
     content = publish_parts(context.data, writer_name='html')['html_body']
     content = wikiwords.sub(check, content)

--- a/docs/tutorials/wiki/src/views/tutorial/views.py
+++ b/docs/tutorials/wiki/src/views/tutorial/views.py
@@ -22,10 +22,10 @@ def view_page(context, request):
         if word in wiki:
             page = wiki[word]
             view_url = request.resource_url(page)
-            return '<a href="%s">%s</a>' % (view_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, word)
         else:
             add_url = request.application_url + '/add_page/' + word 
-            return '<a href="%s">%s</a>' % (add_url, word)
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, word)
 
     content = publish_parts(context.data, writer_name='html')['html_body']
     content = wikiwords.sub(check, content)

--- a/docs/tutorials/wiki2/src/authentication/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/views/default.py
@@ -32,10 +32,10 @@ def view_page(request):
         exists = request.dbsession.query(Page).filter_by(name=word).all()
         if exists:
             view_url = request.route_url('view_page', pagename=word)
-            return '<a href="%s">%s</a>' % (view_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, cgi.escape(word))
         else:
             add_url = request.route_url('add_page', pagename=word)
-            return '<a href="%s">%s</a>' % (add_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, cgi.escape(word))
 
     content = publish_parts(page.data, writer_name='html')['html_body']
     content = wikiwords.sub(add_link, content)

--- a/docs/tutorials/wiki2/src/authorization/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/views/default.py
@@ -25,10 +25,10 @@ def view_page(request):
         exists = request.dbsession.query(Page).filter_by(name=word).all()
         if exists:
             view_url = request.route_url('view_page', pagename=word)
-            return '<a href="%s">%s</a>' % (view_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, cgi.escape(word))
         else:
             add_url = request.route_url('add_page', pagename=word)
-            return '<a href="%s">%s</a>' % (add_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, cgi.escape(word))
 
     content = publish_parts(page.data, writer_name='html')['html_body']
     content = wikiwords.sub(add_link, content)

--- a/docs/tutorials/wiki2/src/tests/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/views/default.py
@@ -25,10 +25,10 @@ def view_page(request):
         exists = request.dbsession.query(Page).filter_by(name=word).all()
         if exists:
             view_url = request.route_url('view_page', pagename=word)
-            return '<a href="%s">%s</a>' % (view_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, cgi.escape(word))
         else:
             add_url = request.route_url('add_page', pagename=word)
-            return '<a href="%s">%s</a>' % (add_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, cgi.escape(word))
 
     content = publish_parts(page.data, writer_name='html')['html_body']
     content = wikiwords.sub(add_link, content)

--- a/docs/tutorials/wiki2/src/views/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/views/default.py
@@ -31,10 +31,10 @@ def view_page(request):
         exists = request.dbsession.query(Page).filter_by(name=word).all()
         if exists:
             view_url = request.route_url('view_page', pagename=word)
-            return '<a href="%s">%s</a>' % (view_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(view_url, cgi.escape(word))
         else:
             add_url = request.route_url('add_page', pagename=word)
-            return '<a href="%s">%s</a>' % (add_url, cgi.escape(word))
+            return '<a href="{0!s}">{1!s}</a>'.format(add_url, cgi.escape(word))
 
     content = publish_parts(page.data, writer_name='html')['html_body']
     content = wikiwords.sub(add_link, content)

--- a/pyramid/asset.py
+++ b/pyramid/asset.py
@@ -29,7 +29,7 @@ def asset_spec_from_abspath(abspath, package):
     pp = package_path(package) + os.path.sep
     if abspath.startswith(pp):
         relpath = abspath[len(pp):]
-        return '%s:%s' % (package_name(package),
+        return '{0!s}:{1!s}'.format(package_name(package),
                           relpath.replace(os.path.sep, '/'))
     return abspath
 

--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -84,14 +84,14 @@ class CallbackAuthenticationPolicy(object):
 
         if self.callback is None:
             debug and self._log(
-                'there was no groupfinder callback; returning %r' % (userid,),
+                'there was no groupfinder callback; returning {0!r}'.format(userid),
                 'authenticated_userid',
                 request)
             return userid
         callback_ok = self.callback(userid, request)
         if callback_ok is not None: # is not None!
             debug and self._log(
-                'groupfinder callback returned %r; returning %r' % (
+                'groupfinder callback returned {0!r}; returning {1!r}'.format(
                     callback_ok, userid),
                 'authenticated_userid',
                 request
@@ -132,7 +132,7 @@ class CallbackAuthenticationPolicy(object):
 
         if userid is None:
             debug and self._log(
-                'unauthenticated_userid returned %r; returning %r' % (
+                'unauthenticated_userid returned {0!r}; returning {1!r}'.format(
                     userid, effective_principals),
                 'effective_principals',
                 request
@@ -157,14 +157,14 @@ class CallbackAuthenticationPolicy(object):
         else:
             groups = self.callback(userid, request)
             debug and self._log(
-                'groupfinder callback returned %r as groups' % (groups,),
+                'groupfinder callback returned {0!r} as groups'.format(groups),
                 'effective_principals',
                 request)
 
         if groups is None: # is None!
             debug and self._log(
-                'returning effective principals: %r' % (
-                    effective_principals,),
+                'returning effective principals: {0!r}'.format(
+                    effective_principals),
                 'effective_principals',
                 request
                 )
@@ -175,8 +175,8 @@ class CallbackAuthenticationPolicy(object):
         effective_principals.extend(groups)
 
         debug and self._log(
-            'returning effective principals: %r' % (
-                effective_principals,),
+            'returning effective principals: {0!r}'.format(
+                effective_principals),
             'effective_principals',
             request
         )
@@ -246,7 +246,7 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
 
         if userid is None:
             self.debug and self._log(
-                'repoze.who.userid is None, returning None' % userid,
+                'repoze.who.userid is None, returning None'.format(*userid),
                 'authenticated_userid',
                 request)
             return None
@@ -290,8 +290,8 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
 
         if identity is None:
             self.debug and self._log(
-                ('repoze.who identity was None; returning %r' %
-                 effective_principals),
+                ('repoze.who identity was None; returning {0!r}'.format(
+                 effective_principals)),
                 'effective_principals',
                 request
                 )
@@ -304,8 +304,8 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
 
         if groups is None: # is None!
             self.debug and self._log(
-                ('security policy groups callback returned None; returning %r' %
-                 effective_principals),
+                ('security policy groups callback returned None; returning {0!r}'.format(
+                 effective_principals)),
                 'effective_principals',
                 request
                 )
@@ -315,8 +315,8 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
 
         if userid is None:
             self.debug and self._log(
-                ('repoze.who.userid was None; returning %r' %
-                 effective_principals),
+                ('repoze.who.userid was None; returning {0!r}'.format(
+                 effective_principals)),
                 'effective_principals',
                 request
                 )
@@ -716,7 +716,7 @@ class AuthTicket(object):
             self.user_data, self.hashalg)
 
     def cookie_value(self):
-        v = '%s%08x%s!' % (self.digest(), int(self.time),
+        v = '{0!s}{1:08x}{2!s}!'.format(self.digest(), int(self.time),
                            url_quote(self.userid))
         if self.tokens:
             v += self.tokens + '!'
@@ -748,7 +748,7 @@ def parse_ticket(secret, ticket, ip, hashalg='md5'):
     try:
         timestamp = int(ticket[digest_size:digest_size + 8], 16)
     except ValueError as e:
-        raise BadTicket('Timestamp is not a hex integer: %s' % e)
+        raise BadTicket('Timestamp is not a hex integer: {0!s}'.format(e))
     try:
         userid, data = ticket[digest_size + 8:].split('!', 1)
     except ValueError:
@@ -993,7 +993,7 @@ class AuthTktCookieHelper(object):
         if encoding_data:
             encoding, encoder = encoding_data
             userid = encoder(userid)
-            user_data = 'userid_type:%s' % encoding
+            user_data = 'userid_type:{0!s}'.format(encoding)
 
         new_tokens = []
         for token in tokens:
@@ -1001,9 +1001,9 @@ class AuthTktCookieHelper(object):
                 try:
                     token = ascii_native_(token)
                 except UnicodeEncodeError:
-                    raise ValueError("Invalid token %r" % (token,))
+                    raise ValueError("Invalid token {0!r}".format(token))
             if not (isinstance(token, str) and VALID_TOKEN.match(token)):
-                raise ValueError("Invalid token %r" % (token,))
+                raise ValueError("Invalid token {0!r}".format(token))
             new_tokens.append(token)
         tokens = tuple(new_tokens)
 
@@ -1142,7 +1142,7 @@ class BasicAuthAuthenticationPolicy(CallbackAuthenticationPolicy):
     def forget(self, request):
         """ Returns challenge headers. This should be attached to a response
         to indicate that credentials are required."""
-        return [('WWW-Authenticate', 'Basic realm="%s"' % self.realm)]
+        return [('WWW-Authenticate', 'Basic realm="{0!s}"'.format(self.realm))]
 
     def callback(self, username, request):
         # Username arg is ignored.  Unfortunately _get_credentials winds up

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -448,7 +448,7 @@ class Configurator(
         package, filename = resolve_asset_spec(path_or_spec, self.package_name)
         if package is None:
             return filename # absolute filename
-        return '%s:%s' % (package, filename)
+        return '{0!s}:{1!s}'.format(package, filename)
 
     def _split_spec(self, path_or_spec):
         return resolve_asset_spec(path_or_spec, self.package_name)
@@ -524,12 +524,12 @@ class Configurator(
     def _add_predicate(self, type, name, factory, weighs_more_than=None,
                        weighs_less_than=None):
         factory = self.maybe_dotted(factory)
-        discriminator = ('%s predicate' % type, name)
+        discriminator = ('{0!s} predicate'.format(type), name)
         intr = self.introspectable(
-            '%s predicates' % type,
+            '{0!s} predicates'.format(type),
             discriminator,
-            '%s predicate named %s' % (type, name),
-            '%s predicate' % type)
+            '{0!s} predicate named {1!s}'.format(type, name),
+            '{0!s} predicate'.format(type))
         intr['name'] = name
         intr['factory'] = factory
         intr['weighs_more_than'] = weighs_more_than
@@ -758,7 +758,7 @@ class Configurator(
         if old_route_prefix is None:
             old_route_prefix = ''
 
-        route_prefix = '%s/%s' % (
+        route_prefix = '{0!s}/{1!s}'.format(
             old_route_prefix.rstrip('/'),
             route_prefix.lstrip('/')
             )
@@ -773,7 +773,7 @@ class Configurator(
                 c = getattr(module, 'includeme')
             except AttributeError:
                 raise ConfigurationError(
-                    "module %r has no attribute 'includeme'" % (module.__name__)
+                    "module {0!r} has no attribute 'includeme'".format((module.__name__))
                     )
                                                        
         spec = module.__name__ + ':' + c.__name__

--- a/pyramid/config/adapters.py
+++ b/pyramid/config/adapters.py
@@ -264,7 +264,7 @@ class AdaptersConfiguratorMixin(object):
         intr = self.introspectable(
             'traversers', 
             discriminator,
-            'traverser for %r' % iface,
+            'traverser for {0!r}'.format(iface),
             'traverser',
             )
         intr['adapter'] = adapter
@@ -316,7 +316,7 @@ class AdaptersConfiguratorMixin(object):
         intr = self.introspectable(
             'resource url adapters', 
             discriminator,
-            'resource url adapter for resource iface %r' % resource_iface,
+            'resource url adapter for resource iface {0!r}'.format(resource_iface),
             'resource url adapter',
             )
         intr['adapter'] = adapter

--- a/pyramid/config/assets.py
+++ b/pyramid/config/assets.py
@@ -221,7 +221,7 @@ class PackageAssetSource(object):
         self.prefix = prefix
 
     def get_path(self, resource_name):
-        return '%s%s' % (self.prefix, resource_name)
+        return '{0!s}{1!s}'.format(self.prefix, resource_name)
 
     def get_filename(self, resource_name):
         path = self.get_path(resource_name)
@@ -382,7 +382,7 @@ class AssetsConfiguratorMixin(object):
         intr = self.introspectable(
             'asset overrides',
             (package, override_package, path, override_prefix),
-            '%s -> %s' % (to_override, override_with),
+            '{0!s} -> {1!s}'.format(to_override, override_with),
             'asset override',
             )
         intr['to_override'] = to_override

--- a/pyramid/config/i18n.py
+++ b/pyramid/config/i18n.py
@@ -83,8 +83,8 @@ class I18NConfiguratorMixin(object):
                 directory = os.path.join(package_path(package), filename)
 
             if not os.path.isdir(os.path.realpath(directory)):
-                raise ConfigurationError('"%s" is not a directory' %
-                                         directory)
+                raise ConfigurationError('"{0!s}" is not a directory'.format(
+                                         directory))
             intr = self.introspectable('translation directories', directory,
                                        spec, 'translation directory')
             intr['directory'] = directory

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -23,7 +23,7 @@ class XHRPredicate(object):
         self.val = bool(val)
 
     def text(self):
-        return 'xhr = %s' % self.val
+        return 'xhr = {0!s}'.format(self.val)
 
     phash = text
 
@@ -39,7 +39,7 @@ class RequestMethodPredicate(object):
         self.val = request_method
 
     def text(self):
-        return 'request_method = %s' % (','.join(self.val))
+        return 'request_method = {0!s}'.format((','.join(self.val)))
 
     phash = text
 
@@ -56,7 +56,7 @@ class PathInfoPredicate(object):
         self.val = val
 
     def text(self):
-        return 'path_info = %s' % (self.orig,)
+        return 'path_info = {0!s}'.format(self.orig)
 
     phash = text
 
@@ -83,9 +83,9 @@ class RequestParamPredicate(object):
         self.reqs = reqs
 
     def text(self):
-        return 'request_param %s' % ','.join(
-            ['%s=%s' % (x,y) if y else x for x, y in self.reqs]
-        )
+        return 'request_param {0!s}'.format(','.join(
+            ['{0!s}={1!s}'.format(x, y) if y else x for x, y in self.reqs]
+        ))
 
     phash = text
 
@@ -109,9 +109,9 @@ class HeaderPredicate(object):
             except re.error as why:
                 raise ConfigurationError(why.args[0])
         if v is None:
-            self._text = 'header %s' % (name,)
+            self._text = 'header {0!s}'.format(name)
         else:
-            self._text = 'header %s=%s' % (name, val_str)
+            self._text = 'header {0!s}={1!s}'.format(name, val_str)
         self.name = name
         self.val = v
 
@@ -133,7 +133,7 @@ class AcceptPredicate(object):
         self.val = val
 
     def text(self):
-        return 'accept = %s' % (self.val,)
+        return 'accept = {0!s}'.format(self.val)
 
     phash = text
 
@@ -145,7 +145,7 @@ class ContainmentPredicate(object):
         self.val = config.maybe_dotted(val)
 
     def text(self):
-        return 'containment = %s' % (self.val,)
+        return 'containment = {0!s}'.format(self.val)
 
     phash = text
 
@@ -158,7 +158,7 @@ class RequestTypePredicate(object):
         self.val = val
 
     def text(self):
-        return 'request_type = %s' % (self.val,)
+        return 'request_type = {0!s}'.format(self.val)
 
     phash = text
 
@@ -173,9 +173,9 @@ class MatchParamPredicate(object):
         self.reqs = [ (x.strip(), y.strip()) for x, y in reqs ]
 
     def text(self):
-        return 'match_param %s' % ','.join(
-            ['%s=%s' % (x,y) for x, y in self.reqs]
-            )
+        return 'match_param {0!s}'.format(','.join(
+            ['{0!s}={1!s}'.format(x, y) for x, y in self.reqs]
+            ))
 
     phash = text
 
@@ -196,7 +196,7 @@ class CustomPredicate(object):
         return getattr(
             self.func,
             '__text__',
-            'custom predicate: %s' % object_description(self.func)
+            'custom predicate: {0!s}'.format(object_description(self.func))
             )
 
     def phash(self):
@@ -206,7 +206,7 @@ class CustomPredicate(object):
         # functions for custom predicates, so that the hash output
         # of predicate instances which are "logically the same"
         # may compare equal.
-        return 'custom:%r' % hash(self.func)
+        return 'custom:{0!r}'.format(hash(self.func))
 
     def __call__(self, context, request):
         return self.func(context, request)
@@ -249,7 +249,7 @@ class CheckCSRFTokenPredicate(object):
         self.val = val
 
     def text(self):
-        return 'check_csrf = %s' % (self.val,)
+        return 'check_csrf = {0!s}'.format(self.val)
 
     phash = text
 
@@ -270,7 +270,7 @@ class PhysicalPathPredicate(object):
             self.val = ('',) + val
 
     def text(self):
-        return 'physical_path = %s' % (self.val,)
+        return 'physical_path = {0!s}'.format(self.val)
 
     phash = text
 
@@ -287,7 +287,7 @@ class EffectivePrincipalsPredicate(object):
             self.val = set((val,))
 
     def text(self):
-        return 'effective_principals = %s' % sorted(list(self.val))
+        return 'effective_principals = {0!s}'.format(sorted(list(self.val)))
 
     phash = text
 

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -342,7 +342,7 @@ class RoutesConfiguratorMixin(object):
 
         intr = self.introspectable('routes',
                                    name,
-                                   '%s (pattern: %r)' % (name, pattern),
+                                   '{0!s} (pattern: {1!r})'.format(name, pattern),
                                    'route')
         intr['name'] = name
         intr['pattern'] = pattern

--- a/pyramid/config/tweens.py
+++ b/pyramid/config/tweens.py
@@ -118,7 +118,7 @@ class TweensConfiguratorMixin(object):
         name = tween_factory
 
         if name in (MAIN, INGRESS):
-            raise ConfigurationError('%s is a reserved tween name' % name)
+            raise ConfigurationError('{0!s} is a reserved tween name'.format(name))
 
         tween_factory = self.maybe_dotted(tween_factory)
 
@@ -132,13 +132,13 @@ class TweensConfiguratorMixin(object):
             if p is not None:
                 if not is_string_or_iterable(p):
                     raise ConfigurationError(
-                        '"%s" must be a string or iterable, not %s' % (t, p))
+                        '"{0!s}" must be a string or iterable, not {1!s}'.format(t, p))
 
         if over is INGRESS or is_nonstr_iter(over) and INGRESS in over:
-            raise ConfigurationError('%s cannot be over INGRESS' % name)
+            raise ConfigurationError('{0!s} cannot be over INGRESS'.format(name))
 
         if under is MAIN or is_nonstr_iter(under) and MAIN in under:
-            raise ConfigurationError('%s cannot be under MAIN' % name)
+            raise ConfigurationError('{0!s} cannot be under MAIN'.format(name))
 
         registry = self.registry
         introspectables = []
@@ -171,7 +171,7 @@ class TweensConfiguratorMixin(object):
         intr = self.introspectable('tweens',
                                    discriminator,
                                    name,
-                                   '%s tween' % tween_type)
+                                   '{0!s} tween'.format(tween_type))
         intr['name'] = name
         intr['factory'] = tween_factory
         intr['type'] = tween_type

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -154,7 +154,7 @@ class PredicateList(object):
                 weights.append(1 << n + 1)
                 preds.append(pred)
         if kw:
-            raise ConfigurationError('Unknown predicate values: %r' % (kw,))
+            raise ConfigurationError('Unknown predicate values: {0!r}'.format(kw))
         # A "order" is computed for the predicate list.  An order is
         # a scoring.
         #

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -249,7 +249,7 @@ class ViewDeriver(object):
                 view_name = getattr(view, '__name__', view)
                 msg = getattr(
                     request, 'authdebug_message',
-                    'Unauthorized: %s failed permission check' % view_name)
+                    'Unauthorized: {0!s} failed permission check'.format(view_name))
                 raise HTTPForbidden(msg, result=result)
             _secured_view.__call_permissive__ = view
             _secured_view.__permitted__ = _permitted
@@ -305,7 +305,7 @@ class ViewDeriver(object):
                 if not predicate(context, request):
                     view_name = getattr(view, '__name__', view)
                     raise PredicateMismatch(
-                        'predicate mismatch for view %s (%s)' % (
+                        'predicate mismatch for view {0!s} ({1!s})'.format(
                             view_name, predicate.text()))
             return view(context, request)
 
@@ -449,7 +449,7 @@ class DefaultViewMapper(object):
             mapped_view = self.map_class_requestonly(view)
         else:
             mapped_view = self.map_class_native(view)
-        mapped_view.__text__ = 'method %s of %s' % (
+        mapped_view.__text__ = 'method {0!s} of {1!s}'.format(
             self.attr or '__call__', object_description(view))
         return mapped_view
 
@@ -475,7 +475,7 @@ class DefaultViewMapper(object):
                 def mapped_view(context, request):
                     return _mapped_view(context, request)
             if self.attr is not None:
-                mapped_view.__text__ = 'attr %s of %s' % (
+                mapped_view.__text__ = 'attr {0!s} of {1!s}'.format(
                     self.attr, object_description(view))
             else:
                 mapped_view.__text__ = object_description(view)
@@ -1140,7 +1140,7 @@ class ViewsConfiguratorMixin(object):
             request_type = self.maybe_dotted(request_type)
             if not IInterface.providedBy(request_type):
                 raise ConfigurationError(
-                    'request_type must be an interface, not %s' % request_type)
+                    'request_type must be an interface, not {0!s}'.format(request_type))
 
         if context is None:
             context = for_
@@ -1192,7 +1192,7 @@ class ViewsConfiguratorMixin(object):
         discriminator = Deferred(discrim_func)
 
         if inspect.isclass(view) and attr:
-            view_desc = 'method %r of %s' % (
+            view_desc = 'method {0!r} of {1!s}'.format(
                 attr, self.object_description(view))
         else:
             view_desc = self.object_description(view)
@@ -1235,8 +1235,8 @@ class ViewsConfiguratorMixin(object):
                     # route configuration should have already happened in
                     # phase 2
                     raise ConfigurationError(
-                        'No route named %s found for view registration' %
-                        route_name)
+                        'No route named {0!s} found for view registration'.format(
+                        route_name))
 
             if renderer is None:
                 # use default renderer if one exists (reg'd in phase 1)
@@ -1399,7 +1399,7 @@ class ViewsConfiguratorMixin(object):
             mapper_intr = self.introspectable(
                 'view mappers',
                 discriminator,
-                'view mapper for %s' % view_desc,
+                'view mapper for {0!s}'.format(view_desc),
                 'view mapper'
                 )
             mapper_intr['mapper'] = mapper
@@ -1648,8 +1648,7 @@ class ViewsConfiguratorMixin(object):
         for arg in ('name', 'permission', 'context', 'for_', 'http_cache'):
             if arg in predicates:
                 raise ConfigurationError(
-                    '%s may not be used as an argument to add_forbidden_view'
-                    % arg
+                    '{0!s} may not be used as an argument to add_forbidden_view'.format(arg)
                 )
 
         if view is None:
@@ -1760,8 +1759,7 @@ class ViewsConfiguratorMixin(object):
         for arg in ('name', 'permission', 'context', 'for_', 'http_cache'):
             if arg in predicates:
                 raise ConfigurationError(
-                    '%s may not be used as an argument to add_notfound_view'
-                    % arg
+                    '{0!s} may not be used as an argument to add_notfound_view'.format(arg)
                 )
 
         if view is None:
@@ -2012,7 +2010,7 @@ class StaticURLInfo(object):
                     result = urljoin(url, subpath)
                     return result + qs + anchor
 
-        raise ValueError('No static URL definition matching %s' % path)
+        raise ValueError('No static URL definition matching {0!s}'.format(path))
 
     def add(self, config, name, spec, **extra):
         # This feature only allows for the serving of a directory and
@@ -2066,11 +2064,11 @@ class StaticURLInfo(object):
 
             # register a route using the computed view, permission, and
             # pattern, plus any extras passed to us via add_static_view
-            pattern = "%s*subpath" % name  # name already ends with slash
+            pattern = "{0!s}*subpath".format(name)  # name already ends with slash
             if config.route_prefix:
-                route_name = '__%s/%s' % (config.route_prefix, name)
+                route_name = '__{0!s}/{1!s}'.format(config.route_prefix, name)
             else:
-                route_name = '__%s' % name
+                route_name = '__{0!s}'.format(name)
             config.add_route(route_name, pattern, **extra)
             config.add_view(
                 route_name=route_name,
@@ -2094,7 +2092,7 @@ class StaticURLInfo(object):
 
         intr = config.introspectable('static views',
                                      name,
-                                     'static view for %r' % name,
+                                     'static view for {0!r}'.format(name),
                                      'static view')
         intr['name'] = name
         intr['spec'] = spec
@@ -2143,7 +2141,7 @@ class StaticURLInfo(object):
 
         intr = config.introspectable('cache busters',
                                      spec,
-                                     'cache buster for %r' % spec,
+                                     'cache buster for {0!r}'.format(spec),
                                      'cache buster')
         intr['cachebust'] = cachebust
         intr['path'] = spec

--- a/pyramid/encode.py
+++ b/pyramid/encode.py
@@ -57,13 +57,13 @@ def urlencode(query, doseq=True):
         if is_nonstr_iter(v):
             for x in v:
                 x = quote_plus(x)
-                result += '%s%s=%s' % (prefix, k, x)
+                result += '{0!s}{1!s}={2!s}'.format(prefix, k, x)
                 prefix = '&'
         elif v is None:
-            result += '%s%s=' % (prefix, k)
+            result += '{0!s}{1!s}='.format(prefix, k)
         else:
             v = quote_plus(v)
-            result += '%s%s=%s' % (prefix, k, v)
+            result += '{0!s}{1!s}={2!s}'.format(prefix, k, v)
 
         prefix = '&'
 

--- a/pyramid/exceptions.py
+++ b/pyramid/exceptions.py
@@ -76,7 +76,7 @@ class ConfigurationConflictError(ConfigurationError):
         r = ["Conflicting configuration actions"]
         items = sorted(self._conflicts.items())
         for discriminator, infos in items:
-            r.append("  For: %s" % (discriminator, ))
+            r.append("  For: {0!s}".format(discriminator ))
             for info in infos:
                 for line in str(info).rstrip().split(CR):
                     r.append("    " + line)
@@ -92,7 +92,7 @@ class ConfigurationExecutionError(ConfigurationError):
         self.etype, self.evalue, self.info = etype, evalue, info
 
     def __str__(self):
-        return "%s: %s\n  in:\n  %s" % (self.etype, self.evalue, self.info)
+        return "{0!s}: {1!s}\n  in:\n  {2!s}".format(self.etype, self.evalue, self.info)
 
 class CyclicDependencyError(Exception):
     """ The exception raised when the Pyramid topological sorter detects a
@@ -106,6 +106,6 @@ class CyclicDependencyError(Exception):
         for cycle in cycles:
             dependent = cycle
             dependees = cycles[cycle]
-            L.append('%r sorts before %r' % (dependent, dependees))
+            L.append('{0!r} sorts before {1!r}'.format(dependent, dependees))
         msg = 'Implicit ordering cycle:' + '; '.join(L)
         return msg

--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -215,7 +215,7 @@ ${body}''')
 
     def __init__(self, detail=None, headers=None, comment=None,
                  body_template=None, **kw):
-        status = '%s %s' % (self.code, self.title)
+        status = '{0!s} {1!s}'.format(self.code, self.title)
         Response.__init__(self, status=status, **kw)
         Exception.__init__(self, detail)
         self.detail = self.message = detail
@@ -244,7 +244,7 @@ ${body}''')
                 page_template = self.html_template_obj
                 br = '<br/>'
                 if comment:
-                    html_comment = '<!-- %s -->' % escape(comment)
+                    html_comment = '<!-- {0!s} -->'.format(escape(comment))
             else:
                 self.content_type = 'text/plain'
                 escape = _no_escape

--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -265,7 +265,7 @@ class Translations(gettext.GNUTranslations, object):
             return cls(fileobj=fp, domain=domain)
 
     def __repr__(self):
-        return '<%s: "%s">' % (type(self).__name__,
+        return '<{0!s}: "{1!s}">'.format(type(self).__name__,
                                self._info.get('project-id-version'))
 
     def add(self, translations, merge=True):

--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -21,7 +21,7 @@ def get_app(config_uri, name=None, options=None, loadapp=loadapp):
     the ``config_uri`` string expecting the format ``inifile#name``.
     If no name is found, the name will default to "main"."""
     path, section = _getpathsec(config_uri, name)
-    config_name = 'config:%s' % path
+    config_name = 'config:{0!s}'.format(path)
     here_dir = os.getcwd()
 
     app = loadapp(
@@ -44,7 +44,7 @@ def get_appsettings(config_uri, name=None, options=None, appconfig=appconfig):
     the ``config_uri`` string expecting the format ``inifile#name``.
     If no name is found, the name will default to "main"."""
     path, section = _getpathsec(config_uri, name)
-    config_name = 'config:%s' % path
+    config_name = 'config:{0!s}'.format(path)
     here_dir = os.getcwd()
     return appconfig(
         config_name,

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -10,7 +10,7 @@ from pyramid.interfaces import IAssetDescriptor
 from pyramid.compat import string_types
 
 ignore_types = [ imp.C_EXTENSION, imp.C_BUILTIN ]
-init_names = [ '__init__%s' % x[0] for x in imp.get_suffixes() if
+init_names = [ '__init__{0!s}'.format(x[0]) for x in imp.get_suffixes() if
                x[0] and x[2] not in ignore_types ]
 
 def caller_path(path, level=2):
@@ -94,7 +94,7 @@ class Resolver(object):
                     __import__(package)
                 except ImportError:
                     raise ValueError(
-                        'The dotted name %r cannot be imported' % (package,)
+                        'The dotted name {0!r} cannot be imported'.format(package)
                         )
                 package = sys.modules[package]
             self.package = package_of(package)
@@ -204,7 +204,7 @@ class AssetResolver(Resolver):
                 package_name = getattr(self.package, '__name__', None)
             if package_name is None:
                 raise ValueError(
-                    'relative spec %r irresolveable without package' % (spec,)
+                    'relative spec {0!r} irresolveable without package'.format(spec)
                 )
         return PkgResourcesAssetDescriptor(package_name, path)
 
@@ -293,7 +293,7 @@ class DottedNameResolver(Resolver):
 
         """
         if not isinstance(dotted, string_types):
-            raise ValueError('%r is not a string' % (dotted,))
+            raise ValueError('{0!r} is not a string'.format(dotted))
         package = self.package
         if package is CALLER_PACKAGE:
             package = caller_package()
@@ -331,7 +331,7 @@ class DottedNameResolver(Resolver):
         if value.startswith(('.', ':')):
             if not package:
                 raise ValueError(
-                    'relative name %r irresolveable without package' % (value,)
+                    'relative name {0!r} irresolveable without package'.format(value)
                     )
             if value in ['.', ':']:
                 value = package.__name__
@@ -339,7 +339,7 @@ class DottedNameResolver(Resolver):
                 value = package.__name__ + value
         # Calling EntryPoint.load with an argument is deprecated.
         # See https://pythonhosted.org/setuptools/history.html#id8
-        ep = pkg_resources.EntryPoint.parse('x=%s' % value)
+        ep = pkg_resources.EntryPoint.parse('x={0!s}'.format(value))
         if hasattr(ep, 'resolve'):
             # setuptools>=10.2
             return ep.resolve()  # pragma: NO COVER
@@ -354,7 +354,7 @@ class DottedNameResolver(Resolver):
         if value == '.':
             if module is None:
                 raise ValueError(
-                    'relative name %r irresolveable without package' % (value,)
+                    'relative name {0!r} irresolveable without package'.format(value)
                 )
             name = module.split('.')
         else:
@@ -393,7 +393,7 @@ class PkgResourcesAssetDescriptor(object):
         self.path = path
 
     def absspec(self):
-        return '%s:%s' % (self.pkg_name, self.path)
+        return '{0!s}:{1!s}'.format(self.pkg_name, self.path)
 
     def abspath(self):
         return os.path.abspath(

--- a/pyramid/registry.py
+++ b/pyramid/registry.py
@@ -222,7 +222,7 @@ class Introspectable(dict):
 
     def __repr__(self):
         self._assert_resolved()
-        return '<%s category %r, discriminator %r>' % (self.__class__.__name__,
+        return '<{0!s} category {1!r}, discriminator {2!r}>'.format(self.__class__.__name__,
                                                        self.category_name,
                                                        self.discriminator)
 

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -285,7 +285,7 @@ class JSON(object):
             result = adapters.lookup((obj_iface,), IJSONAdapter,
                                      default=_marker)
             if result is _marker:
-                raise TypeError('%r is not JSON serializable' % (obj,))
+                raise TypeError('{0!r} is not JSON serializable'.format(obj))
             return result(obj, request)
         return default
 
@@ -415,7 +415,7 @@ class RendererHelper(object):
         factory = self.registry.queryUtility(IRendererFactory, name=self.type)
         if factory is None:
             raise ValueError(
-                'No such renderer factory %s' % str(self.type))
+                'No such renderer factory {0!s}'.format(str(self.type)))
         return factory(self)
 
     def get_renderer(self):

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -244,11 +244,11 @@ def route_request_iface(name, bases=()):
     # zope.interface.interface.Element.__init__ and
     # https://github.com/Pylons/pyramid/issues/232; as a result, always pass
     # __doc__ to the InterfaceClass constructor.
-    iface = InterfaceClass('%s_IRequest' % name, bases=bases,
+    iface = InterfaceClass('{0!s}_IRequest'.format(name), bases=bases,
                            __doc__="route_request_iface-generated interface")
     # for exception view lookups
     iface.combined = InterfaceClass(
-        '%s_combined_IRequest' % name,
+        '{0!s}_combined_IRequest'.format(name),
         bases=(iface, IRequest),
         __doc__='route_request_iface-generated combined interface')
     return iface

--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -83,8 +83,8 @@ class Router(object):
             match, route = info['match'], info['route']
             if route is None:
                 if debug_routematch:
-                    msg = ('no route matched for url %s' %
-                           request.url)
+                    msg = ('no route matched for url {0!s}'.format(
+                           request.url))
                     logger and logger.debug(msg)
             else:
                 attrs['matchdict'] = match

--- a/pyramid/scaffolds/__init__.py
+++ b/pyramid/scaffolds/__init__.py
@@ -34,7 +34,7 @@ class PyramidTemplate(Template):
         separator = "=" * 79
         msg = dedent(
             """
-            %(separator)s
+            {separator!s}
             Tutorials: http://docs.pylonsproject.org/projects/pyramid_tutorials
             Documentation: http://docs.pylonsproject.org/projects/pyramid
 
@@ -42,8 +42,8 @@ class PyramidTemplate(Template):
             Mailing List: http://groups.google.com/group/pylons-discuss
 
             Welcome to Pyramid.  Sorry for the convenience.
-            %(separator)s
-        """ % {'separator': separator})
+            {separator!s}
+        """.format(**{'separator': separator}))
 
         self.out(msg)
         return Template.post(self, command, output_dir, vars)

--- a/pyramid/scaffolds/copydir.py
+++ b/pyramid/scaffolds/copydir.py
@@ -65,11 +65,11 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
     pad = ' ' * (indent * 2)
     if not os.path.exists(dest):
         if verbosity >= 1:
-            out('%sCreating %s/' % (pad, dest))
+            out('{0!s}Creating {1!s}/'.format(pad, dest))
         if not simulate:
             makedirs(dest, verbosity=verbosity, pad=pad)
     elif verbosity >= 2:
-        out('%sDirectory %s exists' % (pad, dest))
+        out('{0!s}Directory {1!s} exists'.format(pad, dest))
     for name in names:
         if use_pkg_resources:
             full = '/'.join([source[1], name])
@@ -89,7 +89,7 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
             sub_file = sub_vars
         if use_pkg_resources and pkg_resources.resource_isdir(source[0], full):
             if verbosity:
-                out('%sRecursing into %s' % (pad, os.path.basename(full)))
+                out('{0!s}Recursing into {1!s}'.format(pad, os.path.basename(full)))
             copy_dir((source[0], full), dest_full, vars, verbosity, simulate,
                      indent=indent + 1, sub_vars=sub_vars,
                      interactive=interactive, overwrite=overwrite,
@@ -97,7 +97,7 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
             continue
         elif not use_pkg_resources and os.path.isdir(full):
             if verbosity:
-                out('%sRecursing into %s' % (pad, os.path.basename(full)))
+                out('{0!s}Recursing into {1!s}'.format(pad, os.path.basename(full)))
             copy_dir(full, dest_full, vars, verbosity, simulate,
                      indent=indent + 1, sub_vars=sub_vars,
                      interactive=interactive, overwrite=overwrite,
@@ -124,8 +124,7 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
                 old_content = f.read()
             if old_content == content:
                 if verbosity:
-                    out('%s%s already exists (same content)' %
-                          (pad, dest_full))
+                    out('{0!s}{1!s} already exists (same content)'.format(pad, dest_full))
                 continue # pragma: no cover
             if interactive:
                 if not query_interactive(
@@ -136,10 +135,10 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
             elif not overwrite:
                 continue # pragma: no cover 
         if verbosity and use_pkg_resources:
-            out('%sCopying %s to %s' % (pad, full, dest_full))
+            out('{0!s}Copying {1!s} to {2!s}'.format(pad, full, dest_full))
         elif verbosity:
             out(
-                '%sCopying %s to %s' % (pad, os.path.basename(full),
+                '{0!s}Copying {1!s} to {2!s}'.format(pad, os.path.basename(full),
                                         dest_full))
         if not simulate:
             with open(dest_full, 'wb') as f:
@@ -157,7 +156,7 @@ def should_skip_file(name):
     if name.endswith(('~', '.bak')):
         return 'Skipping backup file %(filename)s'
     if name.endswith(('.pyc', '.pyo')):
-        return 'Skipping %s file ' % os.path.splitext(name)[1] + '%(filename)s'
+        return 'Skipping {0!s} file '.format(os.path.splitext(name)[1]) + '%(filename)s'
     if name.endswith('$py.class'):
         return 'Skipping $py.class file %(filename)s'
     if name in ('CVS', '_darcs'):
@@ -188,15 +187,15 @@ def query_interactive(src_fn, dest_fn, src_content, dest_content,
     removed = len([l for l in u_diff if l.startswith('-') and
                    not l.startswith('---')])
     if added > removed:
-        msg = '; %i lines added' % (added - removed)
+        msg = '; {0:d} lines added'.format((added - removed))
     elif removed > added:
-        msg = '; %i lines removed' % (removed - added)
+        msg = '; {0:d} lines removed'.format((removed - added))
     else:
         msg = ''
-    out('Replace %i bytes with %i bytes (%i/%i lines changed%s)' % (
+    out('Replace {0:d} bytes with {1:d} bytes ({2:d}/{3:d} lines changed{4!s})'.format(
         len(dest_content), len(src_content),
         removed, len(dest_content.splitlines()), msg))
-    prompt = 'Overwrite %s [y/n/d/B/?] ' % dest_fn
+    prompt = 'Overwrite {0!s} [y/n/d/B/?] '.format(dest_fn)
     while 1:
         if all_answer is None:
             response = input_(prompt).strip().lower()
@@ -209,7 +208,7 @@ def query_interactive(src_fn, dest_fn, src_content, dest_content,
             while os.path.exists(new_dest_fn):
                 n += 1
                 new_dest_fn = dest_fn + '.bak' + str(n)
-            out('Backing up %s to %s' % (dest_fn, new_dest_fn))
+            out('Backing up {0!s} to {1!s}'.format(dest_fn, new_dest_fn))
             if not simulate:
                 shutil.copyfile(dest_fn, new_dest_fn)
             return True
@@ -248,7 +247,7 @@ def makedirs(dir, verbosity, pad):
 
 def substitute_filename(fn, vars):
     for var, value in vars.items():
-        fn = fn.replace('+%s+' % var, str(value))
+        fn = fn.replace('+{0!s}+'.format(var), str(value))
     return fn
 
 def substitute_content(content, vars, filename='<string>',

--- a/pyramid/scaffolds/template.py
+++ b/pyramid/scaffolds/template.py
@@ -38,7 +38,7 @@ class Template(object):
                 substitute_escaped_double_braces(
                     substitute_double_braces(content, TypeMapper(vars))), fsenc)
         except Exception as e:
-            _add_except(e, ' in file %s' % filename)
+            _add_except(e, ' in file {0!s}'.format(filename))
             raise
 
     def module_dir(self):
@@ -54,7 +54,7 @@ class Template(object):
         construct a path.  If _template_dir is a tuple, it should be a
         2-element tuple: ``(package_name, package_relative_path)``."""
         assert self._template_dir is not None, (
-            "Template %r didn't set _template_dir" % self)
+            "Template {0!r} didn't set _template_dir".format(self))
         if isinstance(self._template_dir, tuple):
             return self._template_dir
         else:
@@ -80,7 +80,7 @@ class Template(object):
     def write_files(self, command, output_dir, vars):
         template_dir = self.template_dir()
         if not self.exists(output_dir):
-            self.out("Creating directory %s" % output_dir)
+            self.out("Creating directory {0!s}".format(output_dir))
             if not command.options.simulate:
                 # Don't let copydir create this top-level directory,
                 # since copydir will svn add it sometimes:
@@ -139,7 +139,7 @@ def eval_with_catch(expr, vars):
     try:
         return eval(expr, vars)
     except Exception as e:
-        _add_except(e, 'in expression %r' % expr)
+        _add_except(e, 'in expression {0!r}'.format(expr))
         raise
 
 double_brace_pattern = re.compile(r'{{(?P<braced>.*?)}}')
@@ -155,7 +155,7 @@ escaped_double_brace_pattern = re.compile(r'\\{\\{(?P<escape_braced>[^\\]*?)\\}\
 def substitute_escaped_double_braces(content):
     def escaped_double_bracerepl(match):
         value = match.group('escape_braced').strip()
-        return "{{%(value)s}}" % locals()
+        return "{{{{{value!s}}}}}".format(**locals())
     return escaped_double_brace_pattern.sub(escaped_double_bracerepl, content)
 
 def _add_except(exc, info): # pragma: no cover

--- a/pyramid/scaffolds/tests.py
+++ b/pyramid/scaffolds/tests.py
@@ -50,7 +50,7 @@ class TemplateTest(object):
                     time.sleep(5)
                     proc.poll()
                     if proc.returncode is not None:
-                        raise RuntimeError('%s didnt start' % ininame)
+                        raise RuntimeError('{0!s} didnt start'.format(ininame))
                     conn = httplib.HTTPConnection('localhost:6543')
                     conn.request('GET', '/')
                     resp = conn.getresponse()

--- a/pyramid/scripts/common.py
+++ b/pyramid/scripts/common.py
@@ -11,8 +11,7 @@ def parse_vars(args):
     for arg in args:
         if '=' not in arg:
             raise ValueError(
-                'Variable assignment %r invalid (no "=")'
-                % arg)
+                'Variable assignment {0!r} invalid (no "=")'.format(arg))
         name, value = arg.split('=', 1)
         result[name] = value
     return result

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -112,7 +112,7 @@ class PCreateCommand(object):
             # and combine it with '-branch'
             version_match = re.match(r'(\d+\.\d+)', self.pyramid_dist.version)
             if version_match is not None:
-                pyramid_docs_branch = "%s-branch" % version_match.group()
+                pyramid_docs_branch = "{0!s}-branch".format(version_match.group())
             # if can not parse the version then default to 'latest'
             else:
                 pyramid_docs_branch = 'latest'
@@ -141,7 +141,7 @@ class PCreateCommand(object):
             max_name = max([len(t.name) for t in scaffolds])
             self.out('Available scaffolds:')
             for scaffold in scaffolds:
-                self.out('  %s:%s  %s' % (
+                self.out('  {0!s}:{1!s}  {2!s}'.format(
                     scaffold.name,
                     ' ' * (max_name - len(scaffold.name)), scaffold.summary))
         else:
@@ -157,7 +157,7 @@ class PCreateCommand(object):
                 scaffold = scaffold_class(entry.name)
                 scaffolds.append(scaffold)
             except Exception as e: # pragma: no cover
-                self.out('Warning: could not load entry point %s (%s: %s)' % (
+                self.out('Warning: could not load entry point {0!s} ({1!s}: {2!s})'.format(
                     entry.name, e.__class__.__name__, e))
         return scaffolds
 
@@ -177,7 +177,7 @@ class PCreateCommand(object):
         available = [x.name for x in self.scaffolds]
         diff = set(self.options.scaffold_name).difference(available)
         if diff:
-            self.out('Unavailable scaffolds: %s' % ", ".join(sorted(diff)))
+            self.out('Unavailable scaffolds: {0!s}'.format(", ".join(sorted(diff))))
             return False
 
         pkg_name = self.project_vars['package']

--- a/pyramid/scripts/prequest.py
+++ b/pyramid/scripts/prequest.py
@@ -179,7 +179,7 @@ class PRequestCommand(object):
         if self.options.display_headers:
             self.out(response.status)
             for name, value in response.headerlist:
-                self.out('%s: %s' % (name, value))
+                self.out('{0!s}: {1!s}'.format(name, value))
         if response.charset:
             self.out(response.ubody)
         else:

--- a/pyramid/scripts/proutes.py
+++ b/pyramid/scripts/proutes.py
@@ -30,7 +30,7 @@ def _get_pattern(route):
     pattern = route.pattern
 
     if not pattern.startswith('/'):
-        pattern = '/%s' % pattern
+        pattern = '/{0!s}'.format(pattern)
     return pattern
 
 
@@ -46,7 +46,7 @@ def _get_print_format(fmt, max_name, max_pattern, max_view, max_method):
 
     for index, col in enumerate(fmt):
         size = max_map[col] + PAD
-        print_fmt += '{{%s: <{%s}}} ' % (col, index)
+        print_fmt += '{{{{{0!s}: <{{{1!s}}}}}}} '.format(col, index)
         sizes.append(size)
 
     return print_fmt.format(*sizes)
@@ -88,7 +88,7 @@ def _get_request_methods(route_request_methods, view_request_methods):
     elif request_methods:
         if excludes and request_methods == set([ANY_KEY]):
             for exclude in excludes:
-                request_methods.add('!%s' % exclude)
+                request_methods.add('!{0!s}'.format(exclude))
 
         request_methods = ','.join(sorted(request_methods))
 
@@ -107,7 +107,7 @@ def _get_view_module(view_callable):
 
         if isinstance(original_view, static_view):
             if original_view.package_name is not None:
-                return '%s:%s' % (
+                return '{0!s}:{1!s}'.format(
                     original_view.package_name,
                     original_view.docroot
                 )
@@ -121,9 +121,9 @@ def _get_view_module(view_callable):
         # for them and remove this logic
         view_name = str(view_callable)
 
-    view_module = '%s.%s' % (
+    view_module = '{0!s}.{1!s}'.format(
         view_callable.__module__,
-        view_name,
+        view_name
     )
 
     # If pyramid wraps something in wsgiapp or wsgiapp2 decorators
@@ -194,7 +194,7 @@ def get_route_data(route, registry):
                     if isinstance(request_method, string_types):
                         request_method = (request_method,)
                     elif isinstance(request_method, not_):
-                        request_method = ('!%s' % request_method.value,)
+                        request_method = ('!{0!s}'.format(request_method.value),)
 
                     view_request_methods[view_module].extend(request_method)
                 else:

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -51,7 +51,7 @@ if WIN and not hasattr(os, 'kill'): # pragma: no cover
         kernel32 = ctypes.windll.kernel32
         handle = kernel32.OpenProcess(1, 0, pid)
         if (0 == kernel32.TerminateProcess(handle, 0)):
-            raise OSError('No such process %s' % pid)
+            raise OSError('No such process {0!s}'.format(pid))
 else:
     kill = os.kill
 
@@ -248,7 +248,7 @@ class PServeCommand(object):
 
         if cmd not in (None, 'start', 'stop', 'restart', 'status'):
             self.out(
-                'Error: must give start|stop|restart (not %s)' % cmd)
+                'Error: must give start|stop|restart (not {0!s})'.format(cmd))
             return 2
 
         if cmd == 'status' or self.options.show_status:
@@ -301,7 +301,7 @@ class PServeCommand(object):
             try:
                 writeable_log_file = open(self.options.log_file, 'a')
             except IOError as ioe:
-                msg = 'Error: Unable to write to log file: %s' % ioe
+                msg = 'Error: Unable to write to log file: {0!s}'.format(ioe)
                 raise ValueError(msg)
             writeable_log_file.close()
 
@@ -310,7 +310,7 @@ class PServeCommand(object):
             try:
                 writeable_pid_file = open(self.options.pid_file, 'a')
             except IOError as ioe:
-                msg = 'Error: Unable to write to pid file: %s' % ioe
+                msg = 'Error: Unable to write to pid file: {0!s}'.format(ioe)
                 raise ValueError(msg)
             writeable_pid_file.close()
 
@@ -372,7 +372,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
 
         if self.options.verbose > 0:
             if hasattr(os, 'getpid'):
-                msg = 'Starting server in PID %i.' % os.getpid()
+                msg = 'Starting server in PID {0:d}.'.format(os.getpid())
             else:
                 msg = 'Starting server.'
             self.out(msg)
@@ -387,7 +387,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
                     msg = ' ' + str(e)
                 else:
                     msg = ''
-                self.out('Exiting%s (-v to see traceback)' % msg)
+                self.out('Exiting{0!s} (-v to see traceback)'.format(msg))
 
         if self.options.browser:
             def open_browser():
@@ -446,8 +446,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
         pid = live_pidfile(self.options.pid_file)
         if pid:
             raise DaemonizeException(
-                "Daemon is already running (PID: %s from PID file %s)"
-                % (pid, self.options.pid_file))
+                "Daemon is already running (PID: {0!s} from PID file {1!s})".format(pid, self.options.pid_file))
 
         if self.options.verbose > 0:
             self.out('Entering daemon mode')
@@ -506,26 +505,26 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
                 self.out(msg % (filename, pid_in_file, current_pid))
                 return
         if verbosity > 0:
-            self.out("Removing PID file %s" % filename)
+            self.out("Removing PID file {0!s}".format(filename))
         try:
             os.unlink(filename)
             return
         except OSError as e:
             # Record, but don't give traceback
-            self.out("Cannot remove PID file: (%s)" % e)
+            self.out("Cannot remove PID file: ({0!s})".format(e))
         # well, at least lets not leave the invalid PID around...
         try:
             with open(filename, 'w') as f:
                 f.write('')
         except OSError as e:
-            self.out('Stale PID left in file: %s (%s)' % (filename, e))
+            self.out('Stale PID left in file: {0!s} ({1!s})'.format(filename, e))
         else:
             self.out('Stale PID removed')
 
     def record_pid(self, pid_file):
         pid = os.getpid()
         if self.options.verbose > 1:
-            self.out('Writing PID %s to %s' % (pid, pid_file))
+            self.out('Writing PID {0!s} to {1!s}'.format(pid, pid_file))
         with open(pid_file, 'w') as f:
             f.write(str(pid))
         atexit.register(self._remove_pid_file, pid, pid_file, self.options.verbose)
@@ -533,19 +532,19 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
     def stop_daemon(self): # pragma: no cover
         pid_file = self.options.pid_file or 'pyramid.pid'
         if not os.path.exists(pid_file):
-            self.out('No PID file exists in %s' % pid_file)
+            self.out('No PID file exists in {0!s}'.format(pid_file))
             return 1
         pid = read_pidfile(pid_file)
         if not pid:
-            self.out("Not a valid PID file in %s" % pid_file)
+            self.out("Not a valid PID file in {0!s}".format(pid_file))
             return 1
         pid = live_pidfile(pid_file)
         if not pid:
-            self.out("PID in %s is not valid (deleting)" % pid_file)
+            self.out("PID in {0!s} is not valid (deleting)".format(pid_file))
             try:
                 os.unlink(pid_file)
             except (OSError, IOError) as e:
-                self.out("Could not delete: %s" % e)
+                self.out("Could not delete: {0!s}".format(e))
                 return 2
             return 1
         for j in range(10):
@@ -555,7 +554,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
             kill(pid, signal.SIGTERM)
             time.sleep(1)
         else:
-            self.out("failed to kill web process %s" % pid)
+            self.out("failed to kill web process {0!s}".format(pid))
             return 3
         if os.path.exists(pid_file):
             os.unlink(pid_file)
@@ -564,17 +563,17 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
     def show_status(self): # pragma: no cover
         pid_file = self.options.pid_file or 'pyramid.pid'
         if not os.path.exists(pid_file):
-            self.out('No PID file %s' % pid_file)
+            self.out('No PID file {0!s}'.format(pid_file))
             return 1
         pid = read_pidfile(pid_file)
         if not pid:
-            self.out('No PID in file %s' % pid_file)
+            self.out('No PID in file {0!s}'.format(pid_file))
             return 1
         pid = live_pidfile(pid_file)
         if not pid:
-            self.out('PID %s in %s is not running' % (pid, pid_file))
+            self.out('PID {0!s} in {1!s} is not running'.format(pid, pid_file))
             return 1
-        self.out('Server running in PID %s' % pid)
+        self.out('Server running in PID {0!s}'.format(pid))
         return 0
 
     def restart_with_reloader(self): # pragma: no cover
@@ -622,7 +621,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
                 if exit_code != 3:
                     return exit_code
             if self.options.verbose > 0:
-                self.out('%s %s %s' % ('-' * 20, 'Restarting', '-' * 20))
+                self.out('{0!s} {1!s} {2!s}'.format('-' * 20, 'Restarting', '-' * 20))
 
     def change_user_group(self, user, group): # pragma: no cover
         import pwd
@@ -646,7 +645,7 @@ or Supervisor, all of which support process security.
                     entry = grp.getgrnam(group)
                 except KeyError:
                     raise ValueError(
-                        "Bad group: %r; no such group exists" % group)
+                        "Bad group: {0!r}; no such group exists".format(group))
                 gid = entry.gr_gid
         try:
             uid = int(user)
@@ -656,12 +655,12 @@ or Supervisor, all of which support process security.
                 entry = pwd.getpwnam(user)
             except KeyError:
                 raise ValueError(
-                    "Bad username: %r; no such user exists" % user)
+                    "Bad username: {0!r}; no such user exists".format(user))
             if not gid:
                 gid = entry.pw_gid
             uid = entry.pw_uid
         if self.options.verbose > 0:
-            self.out('Changing user to %s:%s (%s:%s)' % (
+            self.out('Changing user to {0!s}:{1!s} ({2!s}:{3!s})'.format(
                 user, group or '(unknown)', uid, gid))
         if gid:
             os.setgid(gid)
@@ -927,7 +926,7 @@ class Monitor(object): # pragma: no cover
                 filenames.extend(file_callback())
             except:
                 print(
-                    "Error calling reloader callback %r:" % file_callback)
+                    "Error calling reloader callback {0!r}:".format(file_callback))
                 traceback.print_exc()
         for module in list(sys.modules.values()):
             try:
@@ -961,12 +960,12 @@ class Monitor(object): # pragma: no cover
                 if filename.endswith('.py'):
                     is_valid = self.check_syntax(filename)
                 if is_valid:
-                    print("%s changed ..." % filename)
+                    print("{0!s} changed ...".format(filename))
         if new_changes:
             self.pending_reload = True
             if self.syntax_error_files:
                 for filename in sorted(self.syntax_error_files):
-                    print("%s has a SyntaxError; NOT reloading." % filename)
+                    print("{0!s} has a SyntaxError; NOT reloading.".format(filename))
         if self.pending_reload and not self.syntax_error_files:
             self.pending_reload = False
             return False
@@ -1019,7 +1018,7 @@ def wsgiref_server_runner(wsgi_app, global_conf, **kw): # pragma: no cover
     host = kw.get('host', '0.0.0.0')
     port = int(kw.get('port', 8080))
     server = make_server(host, port, wsgi_app)
-    print('Starting HTTP server on http://%s:%s' % (host, port))
+    print('Starting HTTP server on http://{0!s}:{1!s}'.format(host, port))
     server.serve_forever()
 
 # For paste.deploy server instantiation (egg:pyramid#cherrypy)
@@ -1125,10 +1124,9 @@ def cherrypy_server_runner(
     try:
         protocol = is_ssl and 'https' or 'http'
         if host == '0.0.0.0':
-            print('serving on 0.0.0.0:%s view at %s://127.0.0.1:%s' %
-                  (port, protocol, port))
+            print('serving on 0.0.0.0:{0!s} view at {1!s}://127.0.0.1:{2!s}'.format(port, protocol, port))
         else:
-            print('serving on %s://%s:%s' % (protocol, host, port))
+            print('serving on {0!s}://{1!s}:{2!s}'.format(protocol, host, port))
         server.start()
     except (KeyboardInterrupt, SystemExit):
         server.stop()

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -23,7 +23,7 @@ def main(argv=sys.argv, quiet=False):
 
 def python_shell_runner(env, help, interact=interact):
     cprt = 'Type "help" for more information.'
-    banner = "Python %s on %s\n%s" % (sys.version, sys.platform, cprt)
+    banner = "Python {0!s} on {1!s}\n{2!s}".format(sys.version, sys.platform, cprt)
     banner += '\n\n' + help + '\n'
     interact(banner, local=env)
 
@@ -166,12 +166,12 @@ class PShellCommand(object):
         if env_help:
             help += 'Environment:'
             for var in sorted(env_help.keys()):
-                help += '\n  %-12s %s' % (var, env_help[var])
+                help += '\n  {0:<12!s} {1!s}'.format(var, env_help[var])
 
         if self.object_help:
             help += '\n\nCustom Variables:'
             for var in sorted(self.object_help.keys()):
-                help += '\n  %-12s %s' % (var, self.object_help[var])
+                help += '\n  {0:<12!s} {1!s}'.format(var, self.object_help[var])
 
         if shell is None:
             try:
@@ -198,7 +198,7 @@ class PShellCommand(object):
 
         self.out('Available shells:')
         for name in sorted_names:
-            self.out('  %s' % (name,))
+            self.out('  {0!s}'.format(name))
         return 0
 
     def find_all_shells(self):
@@ -243,7 +243,7 @@ class PShellCommand(object):
 
             if shell is None:
                 raise ValueError(
-                    'could not find a shell named "%s"' % user_shell
+                    'could not find a shell named "{0!s}"'.format(user_shell)
                 )
 
         if shell is None:

--- a/pyramid/scripts/pviews.py
+++ b/pyramid/scripts/pviews.py
@@ -186,13 +186,13 @@ class PViewsCommand(object):
 
     def output_route_attrs(self, attrs, indent):
         route = attrs['matched_route']
-        self.out("%sroute name: %s" % (indent, route.name))
-        self.out("%sroute pattern: %s" % (indent, route.pattern))
-        self.out("%sroute path: %s" % (indent, route.path))
-        self.out("%ssubpath: %s" % (indent, '/'.join(attrs['subpath'])))
+        self.out("{0!s}route name: {1!s}".format(indent, route.name))
+        self.out("{0!s}route pattern: {1!s}".format(indent, route.pattern))
+        self.out("{0!s}route path: {1!s}".format(indent, route.path))
+        self.out("{0!s}subpath: {1!s}".format(indent, '/'.join(attrs['subpath'])))
         predicates = ', '.join([p.text() for p in route.predicates])
         if predicates != '':
-            self.out("%sroute predicates (%s)" % (indent, predicates))
+            self.out("{0!s}route predicates ({1!s})".format(indent, predicates))
 
     def output_view_info(self, view_wrapper, level=1):
         indent = "    " * level
@@ -201,16 +201,16 @@ class PViewsCommand(object):
         attr = getattr(view_wrapper, '__view_attr__', None)
         request_attrs = getattr(view_wrapper, '__request_attrs__', {})
         if attr is not None:
-            view_callable = "%s.%s.%s" % (module, name, attr)
+            view_callable = "{0!s}.{1!s}.{2!s}".format(module, name, attr)
         else:
             attr = view_wrapper.__class__.__name__
             if attr == 'function':
                 attr = name
-            view_callable = "%s.%s" % (module, attr)
+            view_callable = "{0!s}.{1!s}".format(module, attr)
         self.out('')
         if 'matched_route' in request_attrs:
-            self.out("%sRoute:" % indent)
-            self.out("%s------" % indent)
+            self.out("{0!s}Route:".format(indent))
+            self.out("{0!s}------".format(indent))
             self.output_route_attrs(request_attrs, indent)
             permission = getattr(view_wrapper, '__permission__', None)
             if not IMultiView.providedBy(view_wrapper):
@@ -218,16 +218,16 @@ class PViewsCommand(object):
                 del request_attrs['matched_route']
                 self.output_view_info(view_wrapper, level + 1)
         else:
-            self.out("%sView:" % indent)
-            self.out("%s-----" % indent)
-            self.out("%s%s" % (indent, view_callable))
+            self.out("{0!s}View:".format(indent))
+            self.out("{0!s}-----".format(indent))
+            self.out("{0!s}{1!s}".format(indent, view_callable))
             permission = getattr(view_wrapper, '__permission__', None)
             if permission is not None:
-                self.out("%srequired permission = %s" % (indent, permission))
+                self.out("{0!s}required permission = {1!s}".format(indent, permission))
             predicates = getattr(view_wrapper, '__predicates__', None)
             if predicates is not None:
                 predicate_text = ', '.join([p.text() for p in predicates])
-                self.out("%sview predicates (%s)" % (indent, predicate_text))
+                self.out("{0!s}view predicates ({1!s})".format(indent, predicate_text))
 
     def run(self):
         if len(self.args) < 2:
@@ -237,17 +237,17 @@ class PViewsCommand(object):
         url = self.args[1]
 
         if not url.startswith('/'):
-            url = '/%s' % url
+            url = '/{0!s}'.format(url)
         request = Request.blank(url)
         env = self.bootstrap[0](config_uri, options=parse_vars(self.args[2:]),
                                 request=request)
         view = self._find_view(request)
         self.out('')
-        self.out("URL = %s" % url)
+        self.out("URL = {0!s}".format(url))
         self.out('')
         if view is not None:
-            self.out("    context: %s" % view.__request_attrs__['context'])
-            self.out("    view name: %s" % view.__request_attrs__['view_name'])
+            self.out("    context: {0!s}".format(view.__request_attrs__['context']))
+            self.out("    view name: {0!s}".format(view.__request_attrs__['view_name']))
         if IMultiView.providedBy(view):
             for dummy, view_wrapper, dummy in view.views:
                 self.output_view_info(view_wrapper)

--- a/pyramid/security.py
+++ b/pyramid/security.py
@@ -235,8 +235,7 @@ def view_execution_permitted(context, request, name=''):
                             'It would not make sense to claim that this view '
                             '"is" or "is not" permitted.')
         return Allowed(
-            'Allowed: view name %r in context %r (no permission defined)' %
-            (name, context))
+            'Allowed: view name {0!r} in context {1!r} (no permission defined)'.format(name, context))
     return view.__permitted__(context, request)
 
 
@@ -255,7 +254,7 @@ class PermitsResult(int):
         return self.msg
 
     def __repr__(self):
-        return '<%s instance at %s with msg %r>' % (self.__class__.__name__,
+        return '<{0!s} instance at {1!s} with msg {2!r}>'.format(self.__class__.__name__,
                                                     id(self),
                                                     self.msg)
 
@@ -300,7 +299,7 @@ class ACLPermitsResult(int):
         return self.msg
 
     def __repr__(self):
-        return '<%s instance at %s with msg %r>' % (self.__class__.__name__,
+        return '<{0!s} instance at {1!s} with msg {2!r}>'.format(self.__class__.__name__,
                                                     id(self),
                                                     self.msg)
 

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -85,7 +85,7 @@ def signed_deserialize(serialized, secret, hmac=hmac):
                               base64.b64decode(bytes_(serialized[40:])))
     except (binascii.Error, TypeError) as e:
         # Badly formed data can make base64 die
-        raise ValueError('Badly formed base64 data: %s' % e)
+        raise ValueError('Badly formed base64 data: {0!s}'.format(e))
 
     try:
         # bw-compat with pyramid <= 1.5b1 where latin1 is the default
@@ -383,8 +383,8 @@ def BaseCookieSessionFactory(
                 ))
             if len(cookieval) > 4064:
                 raise ValueError(
-                    'Cookie value is too long to store (%s bytes)' %
-                    len(cookieval)
+                    'Cookie value is too long to store ({0!s} bytes)'.format(
+                    len(cookieval))
                     )
             response.set_cookie(
                 self._cookie_name,

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -108,14 +108,14 @@ class static_view(object):
         path = _secure_path(path_tuple)
 
         if path is None:
-            raise HTTPNotFound('Out of bounds: %s' % request.url)
+            raise HTTPNotFound('Out of bounds: {0!s}'.format(request.url))
 
         if self.package_name: # package resource
-            resource_path = '%s/%s' % (self.docroot.rstrip('/'), path)
+            resource_path = '{0!s}/{1!s}'.format(self.docroot.rstrip('/'), path)
             if resource_isdir(self.package_name, resource_path):
                 if not request.path_url.endswith('/'):
                     self.add_slash_redirect(request)
-                resource_path = '%s/%s' % (
+                resource_path = '{0!s}/{1!s}'.format(
                     resource_path.rstrip('/'), self.index
                 )
 

--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -150,12 +150,11 @@ class DummyTemplateRenderer(object):
                 myval = self._implementation._received.get(k, _marker)
                 if myval is _marker:
                     raise AssertionError(
-                        'A value for key "%s" was not passed to the renderer'
-                        % k)
+                        'A value for key "{0!s}" was not passed to the renderer'.format(k))
 
             if myval != v:
                 raise AssertionError(
-                    '\nasserted value for %s: %r\nactual value: %r' % (
+                    '\nasserted value for {0!s}: {1!r}\nactual value: {2!r}'.format(
                         k, v, myval))
         return True
 
@@ -557,8 +556,8 @@ class DummyRendererFactory(object):
                 if self.factory:
                     renderer = self.factory(info)
                 else:
-                    raise KeyError('No testing renderer registered for %r' %
-                                   spec)
+                    raise KeyError('No testing renderer registered for {0!r}'.format(
+                                   spec))
         return renderer
 
 

--- a/pyramid/tests/pkgs/eventonly/__init__.py
+++ b/pyramid/tests/pkgs/eventonly/__init__.py
@@ -6,7 +6,7 @@ class Yup(object):
         self.val = val
 
     def text(self):
-        return 'path_startswith = %s' % (self.val,)
+        return 'path_startswith = {0!s}'.format(self.val)
 
     phash = text
 

--- a/pyramid/tests/pkgs/permbugapp/__init__.py
+++ b/pyramid/tests/pkgs/permbugapp/__init__.py
@@ -7,8 +7,8 @@ def x_view(request): # pragma: no cover
 
 def test(context, request):
     # should return false
-     msg = 'Allow ./x? %s' % repr(view_execution_permitted(
-         context, request, 'x'))
+     msg = 'Allow ./x? {0!s}'.format(repr(view_execution_permitted(
+         context, request, 'x')))
      return Response(escape(msg))
 
 def includeme(config):

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -1395,8 +1395,8 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
     def test_unauthenticated_userid(self):
         import base64
         request = testing.DummyRequest()
-        request.headers['Authorization'] = 'Basic %s' % base64.b64encode(
-            bytes_('chrisr:password')).decode('ascii')
+        request.headers['Authorization'] = 'Basic {0!s}'.format(base64.b64encode(
+            bytes_('chrisr:password')).decode('ascii'))
         policy = self._makeOne(None)
         self.assertEqual(policy.unauthenticated_userid(request), 'chrisr')
 
@@ -1426,8 +1426,8 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
     def test_authenticated_userid(self):
         import base64
         request = testing.DummyRequest()
-        request.headers['Authorization'] = 'Basic %s' % base64.b64encode(
-            bytes_('chrisr:password')).decode('ascii')
+        request.headers['Authorization'] = 'Basic {0!s}'.format(base64.b64encode(
+            bytes_('chrisr:password')).decode('ascii'))
         def check(username, password, request):
             return []
         policy = self._makeOne(check)
@@ -1438,8 +1438,8 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
         request = testing.DummyRequest()
         inputs = (b'm\xc3\xb6rk\xc3\xb6:'
                   b'm\xc3\xb6rk\xc3\xb6password').decode('utf-8')
-        request.headers['Authorization'] = 'Basic %s' % (
-            base64.b64encode(inputs.encode('utf-8')).decode('latin-1'))
+        request.headers['Authorization'] = 'Basic {0!s}'.format((
+            base64.b64encode(inputs.encode('utf-8')).decode('latin-1')))
         def check(username, password, request):
             return []
         policy = self._makeOne(check)
@@ -1451,8 +1451,8 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
         request = testing.DummyRequest()
         inputs = (b'm\xc3\xb6rk\xc3\xb6:'
                   b'm\xc3\xb6rk\xc3\xb6password').decode('utf-8')
-        request.headers['Authorization'] = 'Basic %s' % (
-            base64.b64encode(inputs.encode('latin-1')).decode('latin-1'))
+        request.headers['Authorization'] = 'Basic {0!s}'.format((
+            base64.b64encode(inputs.encode('latin-1')).decode('latin-1')))
         def check(username, password, request):
             return []
         policy = self._makeOne(check)
@@ -1462,8 +1462,8 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
     def test_unauthenticated_userid_invalid_payload(self):
         import base64
         request = testing.DummyRequest()
-        request.headers['Authorization'] = 'Basic %s' % base64.b64encode(
-            bytes_('chrisrpassword')).decode('ascii')
+        request.headers['Authorization'] = 'Basic {0!s}'.format(base64.b64encode(
+            bytes_('chrisrpassword')).decode('ascii'))
         policy = self._makeOne(None)
         self.assertEqual(policy.unauthenticated_userid(request), None)
 
@@ -1574,7 +1574,7 @@ class DummyAuthTktModule(object):
                     if isinstance(v, bytes):
                         v = text_(v)
                     new_items.append((k,v))
-                result = '/'.join(['%s=%s' % (k, v) for k,v in new_items ])
+                result = '/'.join(['{0!s}={1!s}'.format(k, v) for k,v in new_items ])
                 return result
         self.AuthTicket = AuthTicket
 

--- a/pyramid/tests/test_config/test_adapters.py
+++ b/pyramid/tests/test_config/test_adapters.py
@@ -265,7 +265,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(intr.type_name, 'traverser')
         self.assertEqual(intr.discriminator, ('traverser', DummyIface))
         self.assertEqual(intr.category_name, 'traversers')
-        self.assertEqual(intr.title, 'traverser for %r' % DummyIface)
+        self.assertEqual(intr.title, 'traverser for {0!r}'.format(DummyIface))
         self.assertEqual(intr['adapter'], DummyTraverser)
         self.assertEqual(intr['iface'], DummyIface)
 

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -4341,7 +4341,7 @@ def assert_similar_datetime(one, two):
         one_attr = getattr(one, attr)
         two_attr = getattr(two, attr)
         if not one_attr == two_attr: # pragma: no cover
-            raise AssertionError('%r != %r in %s' % (one_attr, two_attr, attr))
+            raise AssertionError('{0!r} != {1!r} in {2!s}'.format(one_attr, two_attr, attr))
 
 class DummyStaticURLInfo:
     def __init__(self):

--- a/pyramid/tests/test_path.py
+++ b/pyramid/tests/test_path.py
@@ -286,31 +286,31 @@ class TestPkgResourcesAssetDescriptor(unittest.TestCase):
     def test_stream(self):
         inst = self._makeOne()
         inst.pkg_resources = DummyPkgResource()
-        inst.pkg_resources.resource_stream = lambda x, y: '%s:%s' % (x, y)
+        inst.pkg_resources.resource_stream = lambda x, y: '{0!s}:{1!s}'.format(x, y)
         s = inst.stream()
         self.assertEqual(s,
-                         '%s:%s' % ('pyramid.tests', 'test_asset.py'))
+                         '{0!s}:{1!s}'.format('pyramid.tests', 'test_asset.py'))
 
     def test_isdir(self):
         inst = self._makeOne()
         inst.pkg_resources = DummyPkgResource()
-        inst.pkg_resources.resource_isdir = lambda x, y: '%s:%s' % (x, y)
+        inst.pkg_resources.resource_isdir = lambda x, y: '{0!s}:{1!s}'.format(x, y)
         self.assertEqual(inst.isdir(),
-                         '%s:%s' % ('pyramid.tests', 'test_asset.py'))
+                         '{0!s}:{1!s}'.format('pyramid.tests', 'test_asset.py'))
 
     def test_listdir(self):
         inst = self._makeOne()
         inst.pkg_resources = DummyPkgResource()
-        inst.pkg_resources.resource_listdir = lambda x, y: '%s:%s' % (x, y)
+        inst.pkg_resources.resource_listdir = lambda x, y: '{0!s}:{1!s}'.format(x, y)
         self.assertEqual(inst.listdir(),
-                         '%s:%s' % ('pyramid.tests', 'test_asset.py'))
+                         '{0!s}:{1!s}'.format('pyramid.tests', 'test_asset.py'))
 
     def test_exists(self):
         inst = self._makeOne()
         inst.pkg_resources = DummyPkgResource()
-        inst.pkg_resources.resource_exists = lambda x, y: '%s:%s' % (x, y)
+        inst.pkg_resources.resource_exists = lambda x, y: '{0!s}:{1!s}'.format(x, y)
         self.assertEqual(inst.exists(),
-                         '%s:%s' % ('pyramid.tests', 'test_asset.py'))
+                         '{0!s}:{1!s}'.format('pyramid.tests', 'test_asset.py'))
 
 class TestFSAssetDescriptor(unittest.TestCase):
     def _getTargetClass(self):

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -43,7 +43,7 @@ class TestJSON(unittest.TestCase):
         renderer = self._makeOne()
         renderer.add_adapter(datetime, adapter)
         result = renderer(None)({'a':now}, {'request':request})
-        self.assertEqual(result, '{"a": "%s"}' % now.isoformat())
+        self.assertEqual(result, '{{"a": "{0!s}"}}'.format(now.isoformat()))
 
     def test_with_custom_adapter2(self):
         request = testing.DummyRequest()
@@ -54,7 +54,7 @@ class TestJSON(unittest.TestCase):
         now = datetime.utcnow()
         renderer = self._makeOne(adapters=((datetime, adapter),))
         result = renderer(None)({'a':now}, {'request':request})
-        self.assertEqual(result, '{"a": "%s"}' % now.isoformat())
+        self.assertEqual(result, '{{"a": "{0!s}"}}'.format(now.isoformat()))
 
     def test_with_custom_serializer(self):
         class Serializer(object):

--- a/pyramid/tests/test_response.py
+++ b/pyramid/tests/test_response.py
@@ -26,7 +26,7 @@ class TestFileResponse(unittest.TestCase):
 
     def _getPath(self, suffix='txt'):
         here = os.path.dirname(__file__)
-        return os.path.join(here, 'fixtures', 'minimal.%s' % (suffix,))
+        return os.path.join(here, 'fixtures', 'minimal.{0!s}'.format(suffix))
 
     def test_with_image_content_type(self):
         path = self._getPath('jpg')

--- a/pyramid/tests/test_router.py
+++ b/pyramid/tests/test_router.py
@@ -1346,6 +1346,6 @@ def exc_raised(exc, func, *arg, **kw):
     except exc as e:
         return e
     else:
-        raise AssertionError('%s not raised' % exc) # pragma: no cover
+        raise AssertionError('{0!s} not raised'.format(exc)) # pragma: no cover
 
     

--- a/pyramid/tests/test_scaffolds/test_copydir.py
+++ b/pyramid/tests/test_scaffolds/test_copydir.py
@@ -78,8 +78,8 @@ class Test_copy_dir(unittest.TestCase):
                       2, False,
                       template_renderer=dummy_template_renderer)
         result = self.out.getvalue()
-        self.assertTrue('%s already exists (same content)' % \
-            os.path.join(self.dirname, 'mypackage', '__init__.py') in result)
+        self.assertTrue('{0!s} already exists (same content)'.format( \
+            os.path.join(self.dirname, 'mypackage', '__init__.py')) in result)
 
     def test_direxists_message(self):
         vars = {'package':'mypackage'}
@@ -92,7 +92,7 @@ class Test_copy_dir(unittest.TestCase):
                       2, False,
                       template_renderer=dummy_template_renderer)
         result = self.out.getvalue()
-        self.assertTrue('Directory %s exists' % self.dirname in result, result)
+        self.assertTrue('Directory {0!s} exists'.format(self.dirname) in result, result)
 
     def test_overwrite_false(self):
         vars = {'package':'mypackage'}
@@ -291,7 +291,7 @@ class Test_should_skip_file(unittest.TestCase):
             extension = os.path.splitext(name)[1]
             self.assertEqual(
                 self._callFUT(name),
-                'Skipping %s file ' % extension + '%(filename)s')
+                'Skipping {0!s} file '.format(extension) + '%(filename)s')
 
     def test_should_skip_jython_class_file(self):
         self.assertEqual(

--- a/pyramid/tests/test_scripts/test_pdistreport.py
+++ b/pyramid/tests/test_scripts/test_pdistreport.py
@@ -68,6 +68,6 @@ class DummyDistribution(object):
     def __init__(self, name):
         self.project_name = name
         self.version = '1'
-        self.location = '/projects/%s' % name
+        self.location = '/projects/{0!s}'.format(name)
         
         

--- a/pyramid/tests/test_scripts/test_proutes.py
+++ b/pyramid/tests/test_scripts/test_proutes.py
@@ -265,7 +265,7 @@ class TestPRoutesCommand(unittest.TestCase):
         compare_to = L[-1].split()[:3]
         view_module = 'pyramid.tests.test_scripts.dummy'
         view_str = '<pyramid.tests.test_scripts.dummy.DummyMultiView'
-        final = '%s.%s' % (view_module, view_str)
+        final = '{0!s}.{1!s}'.format(view_module, view_str)
 
         self.assertEqual(
             compare_to,

--- a/pyramid/tests/test_scripts/test_pserve.py
+++ b/pyramid/tests/test_scripts/test_pserve.py
@@ -82,7 +82,7 @@ class TestPServeCommand(unittest.TestCase):
         inst = self._makeOneWithPidFile(os.getpid())
         self._remove_pid_unlink_exception(inst)
         msg = [
-            'Removing PID file %s' % (self.pid_file),
+            'Removing PID file {0!s}'.format((self.pid_file)),
             'Cannot remove PID file: (Some OSError - unlink)',
             'Stale PID removed']
         self._assert_pid_file_not_removed(msg=''.join(msg))
@@ -93,9 +93,9 @@ class TestPServeCommand(unittest.TestCase):
         inst = self._makeOneWithPidFile(os.getpid())
         self._remove_pid_unlink_and_write_exceptions(inst)
         msg = [
-            'Removing PID file %s' % (self.pid_file),
+            'Removing PID file {0!s}'.format((self.pid_file)),
             'Cannot remove PID file: (Some OSError - unlink)',
-            'Stale PID left in file: %s ' % (self.pid_file),
+            'Stale PID left in file: {0!s} '.format((self.pid_file)),
             '(Some OSError - open)']
         self._assert_pid_file_not_removed(msg=''.join(msg))
         with open(self.pid_file) as f:
@@ -141,7 +141,7 @@ class TestPServeCommand(unittest.TestCase):
 
     def _assert_pid_file_removed(self, verbose=False):
         self.assertFalse(os.path.exists(self.pid_file))
-        msg = 'Removing PID file %s' % (self.pid_file) if verbose else ''
+        msg = 'Removing PID file {0!s}'.format((self.pid_file)) if verbose else ''
         self.assertEqual(self.out_.getvalue(), msg)
 
     def _assert_pid_file_not_removed(self, msg):
@@ -177,16 +177,16 @@ class TestPServeCommand(unittest.TestCase):
 
     def test_run_stop_daemon_no_such_pid_file(self):
         path = os.path.join(os.path.dirname(__file__), 'wontexist.pid')
-        inst = self._makeOne('--stop-daemon', '--pid-file=%s' % path)
+        inst = self._makeOne('--stop-daemon', '--pid-file={0!s}'.format(path))
         inst.run()
-        msg = 'No PID file exists in %s' % path
+        msg = 'No PID file exists in {0!s}'.format(path)
         self.assertTrue(msg in self.out_.getvalue())
 
     def test_run_stop_daemon_bad_pid_file(self):
         path = __file__
-        inst = self._makeOne('--stop-daemon', '--pid-file=%s' % path)
+        inst = self._makeOne('--stop-daemon', '--pid-file={0!s}'.format(path))
         inst.run()
-        msg = 'Not a valid PID file in %s' % path
+        msg = 'Not a valid PID file in {0!s}'.format(path)
         self.assertTrue(msg in self.out_.getvalue())
 
     def test_run_stop_daemon_invalid_pid_in_file(self):
@@ -194,9 +194,9 @@ class TestPServeCommand(unittest.TestCase):
         with open(fn, 'wb') as tmp:
             tmp.write(b'9999999')
         tmp.close()
-        inst = self._makeOne('--stop-daemon', '--pid-file=%s' % fn)
+        inst = self._makeOne('--stop-daemon', '--pid-file={0!s}'.format(fn))
         inst.run()
-        msg = 'PID in %s is not valid (deleting)' % fn
+        msg = 'PID in {0!s} is not valid (deleting)'.format(fn)
         self.assertTrue(msg in self.out_.getvalue())
 
     def test_get_options_with_command(self):

--- a/pyramid/tests/test_security.py
+++ b/pyramid/tests/test_security.py
@@ -80,7 +80,7 @@ class TestACLAllowed(unittest.TestCase):
         self.assertTrue(allowed)
         self.assertEqual(str(allowed), msg)
         self.assertTrue('<ACLAllowed instance at ' in repr(allowed))
-        self.assertTrue("with msg %r>" % msg in repr(allowed))
+        self.assertTrue("with msg {0!r}>".format(msg) in repr(allowed))
 
 class TestACLDenied(unittest.TestCase):
     def _getTargetClass(self):
@@ -100,7 +100,7 @@ class TestACLDenied(unittest.TestCase):
         self.assertFalse(denied)
         self.assertEqual(str(denied), msg)
         self.assertTrue('<ACLDenied instance at ' in repr(denied))
-        self.assertTrue("with msg %r>" % msg in repr(denied))
+        self.assertTrue("with msg {0!r}>".format(msg) in repr(denied))
 
 class TestPrincipalsAllowedByPermission(unittest.TestCase):
     def setUp(self):

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -86,8 +86,7 @@ class Test_static_view_use_subpath_False(unittest.TestCase):
         import os
         inst = self._makeOne('pyramid.tests:fixtures/static')
         dds = '..' + os.sep
-        request = self._makeRequest({'PATH_INFO':'/subdir/%s%sminimal.pt' %
-                                     (dds, dds)})
+        request = self._makeRequest({'PATH_INFO':'/subdir/{0!s}{1!s}minimal.pt'.format(dds, dds)})
         context = DummyContext()
         from pyramid.httpexceptions import HTTPNotFound
         self.assertRaises(HTTPNotFound, inst, context, request)

--- a/pyramid/tests/test_traversal.py
+++ b/pyramid/tests/test_traversal.py
@@ -1321,7 +1321,7 @@ class DummyContext(object):
         return self.next
 
     def __repr__(self):
-        return '<DummyContext with name %s at id %s>'%(self.__name__, id(self))
+        return '<DummyContext with name {0!s} at id {1!s}>'.format(self.__name__, id(self))
 
 class DummyRequest:
 

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -444,7 +444,7 @@ class Test_object_description(unittest.TestCase):
 
     def test_nomodule(self):
         o = object()
-        self.assertEqual(self._callFUT(o), 'object %s' % str(o))
+        self.assertEqual(self._callFUT(o), 'object {0!s}'.format(str(o)))
 
     def test_module(self):
         import pyramid
@@ -470,7 +470,7 @@ class Test_object_description(unittest.TestCase):
         inst = Dummy()
         self.assertEqual(
             self._callFUT(inst),
-            "object %s" % str(inst))
+            "object {0!s}".format(str(inst)))
 
     def test_shortened_repr(self):
         inst = ['1'] * 1000

--- a/pyramid/traversal.py
+++ b/pyramid/traversal.py
@@ -108,7 +108,7 @@ def find_resource(resource, path):
     view_name = D['view_name']
     context = D['context']
     if view_name:
-        raise KeyError('%r has no subelement %s' % (context, view_name))
+        raise KeyError('{0!r} has no subelement {1!s}'.format(context, view_name))
     return context
 
 find_model = find_resource # b/w compat (forever)
@@ -578,7 +578,7 @@ the ``safe`` argument to this function.  This corresponds to the
 if PY2:
     # special-case on Python 2 for speed?  unchecked
     def quote_path_segment(segment, safe=''):
-        """ %s """ % quote_path_segment_doc
+        """ {0!s} """.format(quote_path_segment_doc)
         # The bit of this code that deals with ``_segment_cache`` is an
         # optimization: we cache all the computation of URL path segments
         # in this module-scope dictionary with the original string (or
@@ -597,7 +597,7 @@ if PY2:
             return result
 else:
     def quote_path_segment(segment, safe=''):
-        """ %s """ % quote_path_segment_doc
+        """ {0!s} """.format(quote_path_segment_doc)
         # The bit of this code that deals with ``_segment_cache`` is an
         # optimization: we cache all the computation of URL path segments
         # in this module-scope dictionary with the original string (or

--- a/pyramid/url.py
+++ b/pyramid/url.py
@@ -117,7 +117,7 @@ class URLMethodsMixin(object):
                 port = None
         url = scheme + '://' + host
         if port:
-            url += ':%s' % port
+            url += ':{0!s}'.format(port)
 
         url_encoding = getattr(self, 'url_encoding', 'utf-8') # webob 1.2b3+
         bscript_name = bytes_(self.script_name, url_encoding)
@@ -261,7 +261,7 @@ class URLMethodsMixin(object):
         route = mapper.get_route(route_name)
 
         if route is None:
-            raise KeyError('No such route named %s' % route_name)
+            raise KeyError('No such route named {0!s}'.format(route_name))
 
         if route.pregenerator is not None:
             elements, kw = route.pregenerator(self, elements, kw)
@@ -702,7 +702,7 @@ class URLMethodsMixin(object):
                 # /absolute/path it's a relative/path; this means its relative
                 # to the package in which the caller's module is defined.
                 package = caller_package()
-                path = '%s:%s' % (package.__name__, path)
+                path = '{0!s}:{1!s}'.format(package.__name__, path)
 
         try:
             reg = self.registry
@@ -711,7 +711,7 @@ class URLMethodsMixin(object):
 
         info = reg.queryUtility(IStaticURLInfo)
         if info is None:
-            raise ValueError('No static URL definition matching %s' % path)
+            raise ValueError('No static URL definition matching {0!s}'.format(path))
 
         return info.generate(path, self, **kw)
 
@@ -747,7 +747,7 @@ class URLMethodsMixin(object):
                 # /absolute/path it's a relative/path; this means its relative
                 # to the package in which the caller's module is defined.
                 package = caller_package()
-                path = '%s:%s' % (package.__name__, path)
+                path = '{0!s}:{1!s}'.format(package.__name__, path)
 
         kw['_app_url'] = self.script_name
         return self.static_url(path, **kw)
@@ -899,7 +899,7 @@ def static_url(path, request, **kw):
             # /absolute/path it's a relative/path; this means its relative
             # to the package in which the caller's module is defined.
             package = caller_package()
-            path = '%s:%s' % (package.__name__, path)
+            path = '{0!s}:{1!s}'.format(package.__name__, path)
     return request.static_url(path, **kw)
 
 
@@ -918,7 +918,7 @@ def static_path(path, request, **kw):
             # /absolute/path it's a relative/path; this means its relative
             # to the package in which the caller's module is defined.
             package = caller_package()
-            path = '%s:%s' % (package.__name__, path)
+            path = '{0!s}:{1!s}'.format(package.__name__, path)
     return request.static_path(path, **kw)
 
 def current_route_url(request, *elements, **kw):

--- a/pyramid/urldispatch.py
+++ b/pyramid/urldispatch.py
@@ -110,7 +110,7 @@ route_re = re.compile(r'(\{[_a-zA-Z][^{}]*(?:\{[^{}]*\}[^{}]*)*\})')
 
 def update_pattern(matchobj):
     name = matchobj.group(0)
-    return '{%s}' % name[1:]
+    return '{{{0!s}}}'.format(name[1:])
 
 def _compile_route(route):
     # This function really wants to consume Unicode patterns natively, but if
@@ -162,8 +162,8 @@ def _compile_route(route):
             name, reg = name.split(':', 1)
         else:
             reg = '[^/]+'
-        gen.append('%%(%s)s' % native_(name)) # native
-        name = '(?P<%s>%s)' % (name, reg) # unicode
+        gen.append('%({0!s})s'.format(native_(name))) # native
+        name = '(?P<{0!s}>{1!s})'.format(name, reg) # unicode
         rpat.append(name)
         s = pat.pop() # unicode
         if s:
@@ -176,8 +176,8 @@ def _compile_route(route):
             gen.append(quote_path_segment(s, safe='/').replace('%', '%%'))
 
     if remainder:
-        rpat.append('(?P<%s>.*?)' % remainder) # unicode
-        gen.append('%%(%s)s' % native_(remainder)) # native
+        rpat.append('(?P<{0!s}>.*?)'.format(remainder)) # unicode
+        gen.append('%({0!s})s'.format(native_(remainder))) # native
 
     pattern = ''.join(rpat) + '$' # unicode
 

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -323,30 +323,29 @@ def object_description(object):
         return shortrepr(object, '}')
     module = inspect.getmodule(object)
     if module is None:
-        return text_('object %s' % str(object))
+        return text_('object {0!s}'.format(str(object)))
     modulename = module.__name__
     if inspect.ismodule(object):
-        return text_('module %s' % modulename)
+        return text_('module {0!s}'.format(modulename))
     if inspect.ismethod(object):
         oself = getattr(object, '__self__', None)
         if oself is None: # pragma: no cover
             oself = getattr(object, 'im_self', None)
-        return text_('method %s of class %s.%s' %
-                     (object.__name__, modulename,
+        return text_('method {0!s} of class {1!s}.{2!s}'.format(object.__name__, modulename,
                       oself.__class__.__name__))
 
     if inspect.isclass(object):
-        dottedname = '%s.%s' % (modulename, object.__name__)
-        return text_('class %s' % dottedname)
+        dottedname = '{0!s}.{1!s}'.format(modulename, object.__name__)
+        return text_('class {0!s}'.format(dottedname))
     if inspect.isfunction(object):
-        dottedname = '%s.%s' % (modulename, object.__name__)
-        return text_('function %s' % dottedname)
-    return text_('object %s' % str(object))
+        dottedname = '{0!s}.{1!s}'.format(modulename, object.__name__)
+        return text_('function {0!s}'.format(dottedname))
+    return text_('object {0!s}'.format(str(object)))
 
 def shortrepr(object, closer):
     r = str(object)
     if len(r) > 100:
-        r = r[:100] + ' ... %s' % closer
+        r = r[:100] + ' ... {0!s}'.format(closer)
     return r
 
 class Sentinel(object):
@@ -470,13 +469,11 @@ class TopologicalSorter(object):
 
         if not self.req_before.issubset(has_before):
             raise ConfigurationError(
-                'Unsatisfied before dependencies: %s'
-                % (', '.join(sorted(self.req_before - has_before)))
+                'Unsatisfied before dependencies: {0!s}'.format((', '.join(sorted(self.req_before - has_before))))
             )
         if not self.req_after.issubset(has_after):
             raise ConfigurationError(
-                'Unsatisfied after dependencies: %s'
-                % (', '.join(sorted(self.req_after - has_after)))
+                'Unsatisfied after dependencies: {0!s}'.format((', '.join(sorted(self.req_after - has_after))))
             )
 
         sorted_names = []
@@ -537,8 +534,8 @@ class ActionInfo(object):
 
     def __str__(self):
         srclines = self.src.split('\n')
-        src = '\n'.join('    %s' % x for x in srclines)
-        return 'Line %s of file %s:\n%s' % (self.line, self.file, src)
+        src = '\n'.join('    {0!s}'.format(x) for x in srclines)
+        return 'Line {0!s} of file {1!s}:\n{2!s}'.format(self.line, self.file, src)
 
 def action_method(wrapped):
     """ Wrapper to provide the right conflict info report data when a method


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyramid?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyramid?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
